### PR TITLE
Revert "test(deps): require post 1.10.0 git rev of py with Python 3.11"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,8 +74,7 @@ jobs:
                   "tox<3" "pluggy<0.10" "setuptools<40" "virtualenv<15.2"
               tox -e py33  # no support for --skip-missing-interpreters false
           else
-              python3 -m pip install -U tox codecov \
-                  "$(grep -F pytest-dev/py.git@ requirements-test.txt)"
+              python3 -m pip install -U tox codecov
               # We could use tox-gh-actions for this, but that'd result in
               # a whole separate redundant section of versions to maintain;
               # with this approach the matrix alone is enough.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,5 @@
 pytest >=3
 pytest-cov
-# https://github.com/pytest-dev/pytest/issues/9181
-# https://github.com/tox-dev/tox/issues/2249
-git+https://github.com/pytest-dev/py.git@2f03e5a#egg=py; python_version >"3.10"
 
 setuptools
 


### PR DESCRIPTION
This reverts commit efed48e26a9b3eef75133b044ff53309464c6e86.

py 1.11.0 is out with the fix, trust setups to update themselves as
they see fit.