### PR TITLE
chore(pylint): replace strict-informational plugin with `fail-on=I`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,6 @@ mypy ==0.961
 pre-commit >=1.18.2
 
 pylint ==2.14.3
-pylint-strict-informational ==0.1
 
 python-language-server
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,9 +73,9 @@ load-plugins =
     pylint.extensions.overlapping_exceptions,
     pylint.extensions.private_import,
     pylint.extensions.redefined_loop_name,
-    pylint_strict_informational,
 persistent = no
 py-version = 3.3
+fail-on = I
 [pylint.MESSAGES CONTROL]
 disable =
     format,  # handled by black


### PR DESCRIPTION
`fail-on` is available since pylint 2.9.0.