### PR TITLE
ci: pin Python 3.5 and 3.6 builds to ubuntu-20.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,8 +32,6 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - "3.5"
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -46,6 +44,10 @@ jobs:
             os: ubuntu-18.04
           - python-version: "3.4"
             os: ubuntu-18.04
+          - python-version: "3.5"
+            os: ubuntu-20.04
+          - python-version: "3.6"
+            os: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3


### PR DESCRIPTION
The current "latest" 22.04 does not have them at the moment.

Refs https://github.com/actions/setup-python/issues/544