### PR TITLE
chore: drop Python < 3.5 support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,12 +40,6 @@ jobs:
           - "3.12.0-alpha - 3.12"
           - "pypy-3.9"
         include:
-          - python-version: "3.3"
-            os: ubuntu-18.04
-            extra-deps: "'virtualenv<15.2'"
-          - python-version: "3.4"
-            os: ubuntu-18.04
-            extra-deps: "'virtualenv<20.5'"
           - python-version: "3.5"
             os: ubuntu-20.04
           - python-version: "3.6"

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox
 
 
 @nox.session(
-    python=["%s3.%s" % (py, x) for py in ("", "pypy") for x in range(3, 13)]
+    python=["%s3.%s" % (py, x) for py in ("", "pypy") for x in range(5, 13)]
     + ["pyston3"]
 )
 def test(session: nox.Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [tool.black]
 target-version = [
-  "py33",
-  "py34",
   "py35",
   "py36",
   "py37",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,3 @@ pytest >=3
 pytest-cov
 
 setuptools
-
-typing; python_version <"3.5"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,9 @@ project_urls =
     Changelog = https://github.com/scop/hashpipe/blob/main/CHANGELOG.md
 
 [options]
-python_requires = >=3.3
+python_requires = >=3.5
 setup_requires =
     setuptools
-install_requires =
-    typing;python_version<'3.5'
 packages = hashpipe
 scripts = bin/hashpipe
 [options.extras_require]
@@ -46,7 +44,7 @@ noqa-require-code = True
 profile = black
 
 [mypy]
-python_version = 3.4
+python_version = 3.5
 strict = True
 enable_error_code = ignore-without-code
 disallow_any_unimported = True
@@ -80,7 +78,7 @@ load-plugins =
     pylint.extensions.private_import,
     pylint.extensions.redefined_loop_name,
 persistent = no
-py-version = 3.3
+py-version = 3.5
 [pylint.MESSAGES CONTROL]
 disable =
     format,  # handled by black


### PR DESCRIPTION
Seems there are no more LTS Linux distros that only have 3.3 or 3.4. Ubuntu 14.04 and 16.04 (ESM) have 3.5.