### PR TITLE
ci(gitlint): run on pull requests only

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,11 +28,12 @@ jobs:
           source venv/bin/activate
           python3 -m pip install -Ur .github/requirements.txt
       - name: Run gitlint
+        if: github.event_name == 'pull_request'
         run: |
           set -euo pipefail
           source venv/bin/activate
           set -x
-          gitlint --commits "origin/${GITHUB_BASE_REF:-main}..HEAD"
+          gitlint --commits "origin/$GITHUB_BASE_REF..HEAD"
       - uses: pre-commit/action@v3.0.0
 
   test:


### PR DESCRIPTION
No need to run on the default branch; what's in is already in.