### PR TITLE
chore(pre-commit): run mypy on the entire source tree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,10 @@ repos:
         additional_dependencies:
           - #
             venv-run ==0.1.2
-        entry: venv-run mypy
+        entry: venv-run mypy . bin/hashpipe
         types: [python]
+        pass_filenames: false
+        require_serial: true
 
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ disallow_any_unimported = True
 disallow_any_decorated = True
 disallow_any_explicit = True
 warn_unreachable = True
+exclude = ^build/
 [mypy-nox.*,pytest.*,_pytest.*]
 # variable annotations present, errors out with python_version < 3.6
 follow_imports = skip


### PR DESCRIPTION
Running only on modified files may miss things, and our source tree is so small that the full run duration isn't really a problem.