### PR TITLE
ci(renovate): use regex manager instead of a pip requirements hack

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,15 @@
   "semanticCommits": "enabled",
   "commitMessageTopic": "{{depName}}",
   "pip_requirements": {
-    "fileMatch": [
-      "(^|/)(requirements[\\w-]*\\.txt|\\.pre-commit-config\\.yaml)$"
-    ]
+    "fileMatch": ["(^|/)requirements[\\w-]*\\.txt$"]
   },
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.pre-commit-config\\.yaml$"],
+      "matchStrings": ["(?<depName>[\\w-]+)(?<currentValue>==[a-z0-9.]+)"],
+      "datasourceTemplate": "pypi"
+    }
+  ],
   "packageRules": [
     {
       "matchFiles": ["requirements-test.txt"],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,7 @@ repos:
         name: mypy
         language: python
         additional_dependencies:
-          - #
-            venv-run ==0.1.2
+          - venv-run==0.1.2
         entry: venv-run mypy . bin/hashpipe
         types: [python]
         pass_filenames: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements-test.txt
 
-black ==23.1.0
-mypy ==0.990
+black==23.1.0
+mypy==0.990
 nox
-ruff ==0.0.244
+ruff==0.0.244

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest >=3
+pytest>=3
 pytest-cov
 
 setuptools


### PR DESCRIPTION
For updating additional PyPI dependencies in `.pre-commit-config.yaml` (just one remains though).

Allows formatting versioned dependencies without weird whitespace hacks there; take advantage of it and remove the weirdness everywhere.