### PR TITLE
ci(test): install old enough virtualenv for Python <= 3.6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,8 +53,10 @@ jobs:
         include:
           - python-version: "3.5"
             os: ubuntu-20.04
+            extra-deps: "'virtualenv<20.22.0'"
           - python-version: "3.6"
             os: ubuntu-20.04
+            extra-deps: "'virtualenv<20.22.0'"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -76,7 +78,7 @@ jobs:
           restore-keys: test-${{ runner.os }}-${{ matrix.python-version }}-
       - run: |
           set -euxo pipefail
-          python3 -m pip install -U nox codecov
+          python3 -m pip install -U nox codecov ${{ matrix.extra-deps }}
           v="${{ matrix.python-version }}"
           v=${v##* }  # "3.12.0-alpha - 3.12" -> "3.12"
           v=${v//-}   # "pypy-3.9" -> "pypy3.9"


### PR DESCRIPTION
20.22.0 drops support for creating envs for them.