### PR TITLE
chore(mypy): skip argcomplete import for now

### DIFF
--- a/hashpipe/__main__.py
+++ b/hashpipe/__main__.py
@@ -96,7 +96,7 @@ def main(  # noqa: C901
         )
 
     try:
-        import argcomplete  # type: ignore[import]
+        import argcomplete
     except ImportError:
         pass
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ disallow_any_decorated = True
 disallow_any_explicit = True
 warn_unreachable = True
 exclude = ^(build|venv)/
-[mypy-nox.*,pytest.*,_pytest.*]
+[mypy-argcomplete.*,nox.*,pytest.*,_pytest.*]
 # variable annotations present, errors out with python_version < 3.6
 follow_imports = skip
 [mypy-noxfile]


### PR DESCRIPTION
Errors out with `python_version` < 3.6 due to variable annotations in use in recent versions.