### PR TITLE
chore: install extras as part of dev requirements

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,8 @@ jobs:
             lint-${{ hashFiles(
               '.github/requirements.txt',
               'requirements-dev.txt',
-              'requirements-test.txt'
+              'requirements-test.txt',
+              'setup.cfg'
             ) }}
           restore-keys: lint-
       - name: Install dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-e .[completion]
 -r requirements-test.txt
 
 black==23.1.0


### PR DESCRIPTION
For dev time extras usage, and type checking coverage.

argcomplete (from the only extra we have at the moment) related type checking is explicitly disabled for now, but let's just do the right thing here anyway.