### PR TITLE
chore(gitlint): ignore title length for bot made commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -9,3 +9,7 @@ regex-style-search = true
 
 [ignore-body-lines]
 regex = ^(Co-authored-by:|((Refs|See|-) )?https?://)
+
+[ignore-by-author-name]
+regex = \[bot\]
+ignore = body-is-missing,title-max-length


### PR DESCRIPTION
For long action ids such as
`google-github-actions/release-please-action`, they end up quite long.