### PR TITLE
ci(setup-python): fix old pip self upgrade

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,6 +69,11 @@ jobs:
           python-version: |
             ${{ matrix.python-version }}
             >=3.11
+        env:
+          # Use system CA certs for setup-python's auto upgrade of pip to work
+          # on older versions (e.g. 3.5) that do not have pypi.org CA certs in
+          # baseline pip's chain
+          PIP_CERT: /etc/ssl/certs/ca-certificates.crt
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
The certs at disposal of the baseline pip that gets upgrade do not have a chain to trust the current pypi.org cert on e.g. Python 3.5, yielding:
```
Could not fetch URL https://pypi.python.org/simple/pip/: There was a
problem confirming the ssl certificate: [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed (_ssl.c:728) - skipping
```

Point to the system CA cert bundle to fix.