### PR TITLE
ci: switch release-please action to googleapis one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release_please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release_please
         with:
           config-file: .github/release-please-config.json


### PR DESCRIPTION
The google-github-actions one is deprecated and archived.